### PR TITLE
Pimp List with a partial map (named update) similar to updateIf

### DIFF
--- a/src/main/scala/pimpathon/list.scala
+++ b/src/main/scala/pimpathon/list.scala
@@ -26,6 +26,11 @@ object list {
       case x            ⇒ x
     }
 
+    def update(pf: A ~> A): List[A] = self.map {
+      case x if pf.isDefinedAt(x) => pf(x)
+      case x                      => x
+    }
+
     def tapEmpty[Discarded](empty: ⇒ Discarded): List[A] = tap(empty, _ ⇒ {})
     def tapNonEmpty[Discarded](nonEmpty: List[A] ⇒ Discarded): List[A] = tap({}, nonEmpty)
     def tap[Discarded](empty: ⇒ Discarded, nonEmpty: List[A] ⇒ Discarded): List[A] = { uncons(empty, nonEmpty); self }

--- a/src/test/scala/pimpathon/list.scala
+++ b/src/test/scala/pimpathon/list.scala
@@ -196,4 +196,8 @@ class ListTest {
     val decrement = (x: Int) => x-1
     List.range(1, 6).updateIf(isEven, decrement) === List(1, 1, 3, 3, 5)
   }
+
+  @Test def update(): Unit = {
+    List.range(1, 6).update { case x if x % 2 == 0 => x - 1 } === List(1, 1, 3, 3, 5)
+  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.8.17"
+version in ThisBuild := "1.8.18"


### PR DESCRIPTION
Hello,

I'm used to have the following version of  updateIf, which takes a PartialFunction as parameter:

```scala
def update(pf: A ~> A): List[A] = self.map {
  case x if pf.isDefinedAt(x) => pf(x)
  case x                      => x
}
```

which translates into:

```scala
List.range(1, 6).update { case x if x % 2 == 0 => x - 1 } === List(1, 1, 3, 3, 5)
```

Hope that makes sens as part of your pimps.

Not sure about the naming as `update` is kind of very generic. I sometimes called it `partialMap`, but `update` is shorter.
