### PR TITLE
Add pimps to List[(K, V)]: keys, values, mapValues, flatMapValues

### DIFF
--- a/src/main/scala/pimpathon/list.scala
+++ b/src/main/scala/pimpathon/list.scala
@@ -164,7 +164,14 @@ object list {
   implicit class ListOfTuple2Pimps[K, V](self: List[(K, V)]) extends GenTraversableLikeOfTuple2Mixin[K, V] {
     def mapFirst[C](f: K => C): List[(C, V)] = mapC(k => v => (f(k), v))
     def mapSecond[W](f: V => W): List[(K, W)] = mapC(k => v => (k, f(v)))
+    def mapValues[W](f: V => W): List[(K, W)] = mapC(k => v => (k, f(v)))
     def mapC[W](f: K ⇒ V ⇒ W): List[W] = self.map(kv ⇒ f(kv._1)(kv._2))
+
+    def flatMapValues[W](f: V => TraversableOnce[W]): Seq[(K, W)] =
+      self.flatMap { case (k, v) => f(v).map(vb => (k, vb)) }
+
+    def keys: List[K] = self.map(_._1)
+    def values: List[V] = self.map(_._2)
 
     protected def gtl: GTLGT[(K, V)] = self
   }

--- a/src/test/scala/pimpathon/list.scala
+++ b/src/test/scala/pimpathon/list.scala
@@ -89,6 +89,24 @@ class ListTest {
   @Test def mapSecond(): Unit =
     on(nil[(Int, Int)], List((1, 2), (2, 3))).calling(_.mapSecond(_ * 2)).produces(nil[(Int, Int)], List((1, 4), (2, 6)))
 
+  @Test def mapValues(): Unit =
+    on(nil[(Int, Int)], List((1, 2), (2, 3))).calling(_.mapValues(_ * 2)).produces(nil[(Int, Int)], List((1, 4), (2, 6)))
+
+  @Test def flatMapValues(): Unit = {
+    on(nil[(String, Int)], List(("a", 1), ("b", 2)))
+      .calling(_.flatMapValues(v => (0 to 2).map(i => v * i)))
+      .produces(nil[(String, Int)], List(("a", 0), ("a", 1), ("a", 2), ("b", 0), ("b", 2), ("b", 4)))
+    on(nil[(String, Int)], List(("a", 1), ("b", 2)))
+      .calling(_.flatMapValues{ case 1 => Some(10); case _ => None })
+      .produces(nil[(String, Int)], List(("a", 10)))
+  }
+
+  @Test def keys(): Unit =
+    List((2,1), (4,2), (6,3), (4, 1)).keys === List(2, 4, 6, 4)
+
+  @Test def values(): Unit =
+    List((2,1), (4,2), (6,3), (4, 1)).values === List(1, 2, 3, 1)
+
   @Test def lpair(): Unit =
     on(nil[Int], List(1, 2, 3)).calling(_.lpair(_ * 2)).produces(nil[(Int, Int)], List((2,1), (4,2), (6,3)))
 


### PR DESCRIPTION
Hello,

This is a suggestion for a bunch of pimps on `List[(K, V)]`:

* `keys` which is `.map(_._1)`
* `values` which is `.map(_._2)`
* `mapValues` which is an alias for `mapSecond`
* `flatMapValues` which is the `flatMap` equivalent of `mapValues`
